### PR TITLE
Fix shadowJar service file merging

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -53,5 +53,8 @@ tasks {
     shadowJar {
         mergeServiceFiles()
         archiveClassifier.set("shaded")
+        filesMatching("META-INF/services/**") {
+            duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.INCLUDE
+        }
     }
 }


### PR DESCRIPTION
Shadow's default `duplicatesStrategy` is `EXCLUDE`, which runs before resource transformers. This caused only one JAR's `META-INF/services/...` entries to survive, dropping core Flyway plugins (e.g. `DryRunConfigurationExtensionStub`) from the shaded jar and breaking startup of the Nix-packaged service.

Override the strategy for service files so `mergeServiceFiles()` actually merges them.