### PR TITLE
Make bubblewrap options configurable

### DIFF
--- a/server/src/main/kotlin/at/yawk/javap/Bubblewrap.kt
+++ b/server/src/main/kotlin/at/yawk/javap/Bubblewrap.kt
@@ -6,7 +6,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-class Bubblewrap {
+class Bubblewrap(private val config: JavapConfiguration.Bubblewrap = JavapConfiguration.Bubblewrap()) {
     private val basicCommand: List<String>
 
     init {
@@ -25,7 +25,8 @@ class Bubblewrap {
                         .flatMap { listOf("--ro-bind", it.toString(), it.toString()) } +
                 // copy the links
                 bindLocations.filter { Files.isSymbolicLink(it) }
-                        .flatMap { listOf("--symlink", Files.readSymbolicLink(it).toString(), it.toString()) }
+                        .flatMap { listOf("--symlink", Files.readSymbolicLink(it).toString(), it.toString()) } +
+                config.extraArgs
     }
 
     fun executeCommand(

--- a/server/src/main/kotlin/at/yawk/javap/JavapApplication.kt
+++ b/server/src/main/kotlin/at/yawk/javap/JavapApplication.kt
@@ -49,7 +49,7 @@ fun main(args: Array<String>) {
     val jdbi = Jdbi.create(dataSource).installPlugins()
     val sdkProvider = SdkProviderImpl()
     sdkProvider.start()
-    val processor = LocalProcessor(sdkProvider, Bubblewrap())
+    val processor = LocalProcessor(sdkProvider, Bubblewrap(config.bubblewrap))
     val pasteResource = PasteResource(
             json,
             jdbi.onDemand(PasteDao::class.java),

--- a/server/src/main/kotlin/at/yawk/javap/JavapConfiguration.kt
+++ b/server/src/main/kotlin/at/yawk/javap/JavapConfiguration.kt
@@ -15,12 +15,18 @@ import kotlinx.serialization.Serializable
 data class JavapConfiguration(
         val database: Database,
         val bindAddress: String = "127.0.0.1",
-        val bindPort: Int = 8080
+        val bindPort: Int = 8080,
+        val bubblewrap: Bubblewrap = Bubblewrap()
 ) {
     @Serializable
     data class Database(
             val user: String? = null,
             val password: String? = null,
             val url: String
+    )
+
+    @Serializable
+    data class Bubblewrap(
+            val extraArgs: List<String> = emptyList()
     )
 }


### PR DESCRIPTION
Adds a `bubblewrap.extraArgs` config field. The list of raw strings is appended to the bwrap command, so deployments can add extra `--ro-bind`, `--setenv`, etc. as needed.

This is especially useful on NixOS, where the JDK/compiler symlinks point into `/nix/store` and the default sandbox does not bind it.