### PR TITLE
Fix Kotlin/JS source layout and distribution output path

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -12,6 +12,9 @@ kotlin {
 
     sourceSets {
         jsMain {
+            kotlin.srcDir("src/main/kotlin")
+            resources.srcDir("src/main/resources")
+
             dependencies {
                 implementation(project(":shared"))
                 implementation(libs.kotlinx.serialization.json)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -51,7 +51,7 @@ tasks {
         from(project(":client").file("src/main/resources/static")) {
             into("static")
         }
-        from(project(":client").layout.buildDirectory.dir("distributions")) {
+        from(project(":client").layout.buildDirectory.dir("dist/js/productionExecutable")) {
             include("client.js", "client.js.map")
         }
     }


### PR DESCRIPTION
The jsMain source set defaults to src/jsMain, but the client sources and resources live under src/main. Add explicit srcDirs so Gradle finds them.

Also point the server processResources task at the actual Kotlin/JS distribution output directory (dist/js/productionExecutable) instead of build/distributions, which is empty with the current plugin version.